### PR TITLE
Improve error message in case where npm is not installed

### DIFF
--- a/dapps/src/js.rs
+++ b/dapps/src/js.rs
@@ -52,7 +52,7 @@ pub fn build(path: &str) {
 		.arg("--no-progress")
 		.current_dir(path)
 		.status()
-		.unwrap_or_else(|e| die("Installing dependencies", e));
+		.unwrap_or_else(|e| die("Installing node.js dependencies with npm", e));
 	assert!(child.success(), "There was an error installing dependencies.");
 
 	let child = platform::handle_fd(&mut Command::new(platform::NPM_CMD))


### PR DESCRIPTION
Before:

```
thread '<main>' panicked at 'Error: Installing dependencies: Error {
repr: Os { code: 2, message: "No such file or directory" } }',
/Users/nipunn/src/parity-ui/status/target/release/build/parity-dapps-8fd1c3f8edf63124/out/lib.rs:465
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

After:

```
thread '<main>' panicked at 'Error: Installing node.js dependencies with
npm: Error { repr: Os { code: 2, message: "No such file or directory" }
}',
/Users/nipunn/src/parity-ui/status/target/release/build/parity-dapps-8fd1c3f8edf63124/out/lib.rs:464
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```
