### PR TITLE
Fix order of rm arguments

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -13,7 +13,7 @@
     "prebuild": "npm run clean",
     "build": "webpack --bail --progress --colors || true",
     "localPublish": "npm run build && npm publish",
-    "clean": "rm build -rf"
+    "clean": "rm -rf build"
   },
   "author": "Ethcore <admin@ethcore.io>",
   "license": "GPL-3.0",


### PR DESCRIPTION
This order doesn't work on my platform (OSX).
